### PR TITLE
🧹organize tests, rename `match` to `contains`

### DIFF
--- a/clues.js
+++ b/clues.js
@@ -1,5 +1,5 @@
 module.exports = {
-  match: {
+  contains: {
     fn: (item, alt) => alt.includes(item),
     message: value => `Alt text should not contain "${value}".`,
     rules: [

--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@ const rules = require("./rules");
 
 function altText(alt) {
   alt = alt.toLowerCase();
-  let warning = [
+  const warning = [
     ...rules.checkClue(alt),
     ...rules.checkLength(alt),
-    ...rules.checkOnlySpace(alt)
+    ...rules.checkOnlySpace(alt),
+    ...rules.checkPeriod(alt)
   ];
-  warning = [...warning, ...rules.checkPeriod(alt, warning)];
   return warning.length ? warning.join(" ") : undefined;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const rules = require("./rules");
 
 function altText(alt) {
-  // make alt text lowercase to solve for case insensitivity
   alt = alt.toLowerCase();
   let warning = [
     ...rules.checkClue(alt),
@@ -9,7 +8,6 @@ function altText(alt) {
     ...rules.checkOnlySpace(alt)
   ];
   warning = [...warning, ...rules.checkPeriod(alt, warning)];
-  // if warning has length, return it.
   return warning.length ? warning.join(" ") : undefined;
 }
 

--- a/rules.js
+++ b/rules.js
@@ -24,8 +24,8 @@ function checkOnlySpace(alt) {
   return alt == " " ? ["Alt text must not only contain a space."] : [];
 }
 
-function checkPeriod(alt, warning) {
-  return !alt.endsWith(".") && alt.length > 1 && !warning.length
+function checkPeriod(alt) {
+  return !alt.endsWith(".") && alt.length > 1
     ? ["Alt text should end in a period."]
     : [];
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,7 +1,7 @@
 const test = require("tape");
 const altText = require("../");
 
-test("return no warning", assert => {
+test("[altText] return no warning", assert => {
   assert.equal(altText("A large black dog."), undefined);
   assert.equal(altText("A child holding a photograph."), undefined);
   assert.equal(
@@ -11,60 +11,21 @@ test("return no warning", assert => {
   assert.end();
 });
 
-test("clues.checkClue.endWith", assert => {
-  assert.equal(
-    altText("A screenshot of a dog.jpg"),
-    'Alt text should not contain "screenshot of". Alt text should not end with ".jpg".',
-    "can have more than one warning"
-  );
-  assert.equal(altText("DSC_0010.jpg"), 'Alt text should not end with ".jpg".');
-  assert.equal(
-    altText("placeholder graphic"),
-    'Alt text should not end with "graphic".'
-  );
-  assert.end();
-});
-
-test("clues.checkClue.startWith", assert => {
-  assert.equal(
-    altText("spacer image."),
-    'Alt text should not start with "spacer".'
-  );
-  assert.end();
-});
-
-test("clues.checkClue.contain", assert => {
-  assert.equal(
-    altText("A screenshot of a dog."),
-    'Alt text should not contain "screenshot of".'
-  );
+test("[altText] return warnings", assert => {
   assert.equal(
     altText("A SCREENSHOT OF A DOG."),
     'Alt text should not contain "screenshot of".',
-    "clue matching is case insensitive"
+    "alt text rules are case insensitive"
   );
-  assert.end();
-});
 
-test("clues.checkPeriod", assert => {
   assert.equal(
-    altText("a large black dog"),
+    altText("A SCREENSHOT OF A DOG"),
+    'Alt text should not contain "screenshot of". Alt text should end in a period.',
+    "more than one warning"
+  );
+  assert.equal(
+    altText("An inhaler with a spacer connected to the mouthpiece"),
     "Alt text should end in a period."
   );
-  assert.end();
-});
-
-test("clues.checkLength", assert => {
-  assert.equal(
-    altText(
-      "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-    ),
-    "Alt text should be fewer than 100 characters."
-  );
-  assert.end();
-});
-
-test("clues.checkOnlySpace", assert => {
-  assert.equal(altText(" "), "Alt text must not only contain a space.");
   assert.end();
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,58 +1,70 @@
 const test = require("tape");
 const altText = require("../");
 
-test("altText", assert => {
+test("return no warning", assert => {
+  assert.equal(altText("A large black dog."), undefined);
+  assert.equal(altText("A child holding a photograph."), undefined);
   assert.equal(
-    altText("A screenshot of a dog."),
-    'Alt text should not contain "screenshot of".'
+    altText("An inhaler with a spacer connected to the mouthpiece."),
+    undefined
   );
+  assert.end();
+});
 
-  assert.equal(
-    altText("A SCREENSHOT OF A DOG."),
-    'Alt text should not contain "screenshot of".',
-    "clue matching is case insensitive"
-  );
-
+test("clues.checkClue.endWith", assert => {
   assert.equal(
     altText("A screenshot of a dog.jpg"),
     'Alt text should not contain "screenshot of". Alt text should not end with ".jpg".',
     "can have more than one warning"
   );
+  assert.equal(altText("DSC_0010.jpg"), 'Alt text should not end with ".jpg".');
+  assert.equal(
+    altText("placeholder graphic"),
+    'Alt text should not end with "graphic".'
+  );
+  assert.end();
+});
 
+test("clues.checkClue.startWith", assert => {
+  assert.equal(
+    altText("spacer image."),
+    'Alt text should not start with "spacer".'
+  );
+  assert.end();
+});
+
+test("clues.checkClue.contain", assert => {
+  assert.equal(
+    altText("A screenshot of a dog."),
+    'Alt text should not contain "screenshot of".'
+  );
+  assert.equal(
+    altText("A SCREENSHOT OF A DOG."),
+    'Alt text should not contain "screenshot of".',
+    "clue matching is case insensitive"
+  );
+  assert.end();
+});
+
+test("clues.checkPeriod", assert => {
   assert.equal(
     altText("a large black dog"),
     "Alt text should end in a period."
   );
+  assert.end();
+});
 
-  assert.equal(altText("A large black dog."), undefined);
-
+test("clues.checkLength", assert => {
   assert.equal(
     altText(
       "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
     ),
     "Alt text should be fewer than 100 characters."
   );
+  assert.end();
+});
 
+test("clues.checkOnlySpace", assert => {
   assert.equal(altText(" "), "Alt text must not only contain a space.");
-
-  assert.equal(
-    altText("spacer image."),
-    'Alt text should not start with "spacer".'
-  );
-
-  assert.equal(altText("A child holding a photograph."), undefined);
-
-  assert.equal(
-    altText("An inhaler with a spacer connected to the mouthpiece."),
-    undefined
-  );
-
-  assert.equal(altText("DSC_0010.jpg"), 'Alt text should not end with ".jpg".');
-
-  assert.equal(
-    altText("placeholder graphic"),
-    'Alt text should not end with "graphic".'
-  );
-
   assert.end();
 });

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -1,0 +1,58 @@
+const test = require("tape");
+const rules = require("../rules");
+
+test("[rules] checkClue.endWith", assert => {
+  assert.deepEqual(
+    rules.checkClue("A screenshot of a dog.jpg"),
+    [
+      'Alt text should not contain "screenshot of".',
+      'Alt text should not end with ".jpg".'
+    ],
+    "can have more than one warning"
+  );
+  assert.deepEqual(rules.checkClue("DSC_0010.jpg"), [
+    'Alt text should not end with ".jpg".'
+  ]);
+  assert.deepEqual(rules.checkClue("placeholder graphic"), [
+    'Alt text should not end with "graphic".'
+  ]);
+  assert.end();
+});
+
+test("[rules] checkClue.startWith", assert => {
+  assert.deepEqual(rules.checkClue("spacer image."), [
+    'Alt text should not start with "spacer".'
+  ]);
+  assert.end();
+});
+
+test("[rules] checkClue.contain", assert => {
+  assert.deepEqual(rules.checkClue("A screenshot of a dog."), [
+    'Alt text should not contain "screenshot of".'
+  ]);
+  assert.end();
+});
+
+test("[rules] checkPeriod", assert => {
+  assert.deepEqual(rules.checkPeriod("a large black dog"), [
+    "Alt text should end in a period."
+  ]);
+  assert.end();
+});
+
+test("[rules] checkLength", assert => {
+  assert.deepEqual(
+    rules.checkLength(
+      "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    ),
+    ["Alt text should be fewer than 100 characters."]
+  );
+  assert.end();
+});
+
+test("[rules] checkOnlySpace", assert => {
+  assert.deepEqual(rules.checkOnlySpace(" "), [
+    "Alt text must not only contain a space."
+  ]);
+  assert.end();
+});


### PR DESCRIPTION
fixes #14 