### PR TITLE
📝Generate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Warning:
 
 Warning:
 
-> Alt text length should be less than 100 characters, it is currently characters.
+> Alt text length should be less than 100 characters, it is currently characters
 
 ### Image is link
 

--- a/README.md
+++ b/README.md
@@ -58,22 +58,22 @@ Error message:
 
 Error message:
 
-> Alt text should not contain "x".
+> Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>".
 
 ### Alt text could be considered problematic
 
 Error message:
 
-> Alt text should not be "x".
+> Alt text should not be "<image|graphic|photo|photograph|placeholder|temp|alt|drawing|painting|artwork|logo|bullet|button|arrow|more|spacer|blank|chart|table|diagram|graph|\*>".
 
 ### Alt text should not end with
 
 Error message:
 
-> Alt text should not end with "x".
+> Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|graphic>".
 
 ### Alt text should not start with
 
 Error message:
 
-> Alt text should not start with "x".
+> Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>".

--- a/README.md
+++ b/README.md
@@ -37,3 +37,43 @@ console.log(altText("A screenshot of a dog"));
 - WCAG 2.1 1.1.1 Non-text content https://webaim.org/standards/wcag/checklist#sc1.1.1
 - WCAG 2.1 2.4.4 Link purpose (in context) https://webaim.org/standards/wcag/checklist#sc2.4.4
 - Webaim WAVE documentation https://wave.webaim.org/api/docs?format=html
+
+## Warnings
+
+<!-- this section is generated on commit !-->
+
+### Image is link
+
+Error message:
+
+> Images inside a link tag require alt text that describes the purpose of the link.
+
+### Missing alt attribute
+
+Error message:
+
+> Missing `alt` attribute.
+
+### Alt text contains problematic words
+
+Error message:
+
+> Alt text should not contain "x".
+
+### Alt text could be considered problematic
+
+Error message:
+
+> Alt text should not be "x".
+
+### Alt text should not end with
+
+Error message:
+
+> Alt text should not end with "x".
+
+### Alt text should not start with
+
+Error message:
+
+> Alt text should not start with "x".

--- a/README.md
+++ b/README.md
@@ -37,34 +37,73 @@ console.log(altText("A screenshot of a dog"));
 - WCAG 2.1 1.1.1 Non-text content https://webaim.org/standards/wcag/checklist#sc1.1.1
 - WCAG 2.1 2.4.4 Link purpose (in context) https://webaim.org/standards/wcag/checklist#sc2.4.4
 - Webaim WAVE documentation https://wave.webaim.org/api/docs?format=html
+- https://dequeuniversity.com/rules/axe/3.0/image-alt
 
 ## Warnings
 
 <!-- this section is generated on commit !-->
 
-### Should not only contain a space
+### Empty alt text
 
-Warning: `Alt text should not only contain a space`
+Warning: `Alt text should not be a single space`
+
+If you use a null (empty) text alternative (`alt=""`) to hide decorative images, make sure that there is no space character in between the quotes. **If a space character is present, the image may not be effectively hidden from assistive technologies.** For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes.
+
+Sources:
+
+- <https://www.w3.org/WAI/tutorials/images/tips/#tips>
 
 ### Character length
 
-Warning: `Alt text length should be less than 100 characters, it is currently characters`
+Warning: `Alt text length should be less than 125 characters, it is currently characters`
+
+Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks.
+
+Sources:
+
+- <https://accessibility.psu.edu/images/imageshtml/#alt>
+- <https://terrillthompson.com/tests/altlength.html>
 
 ### Image is link
 
 Warning: `Images inside a link tag require alt text that describes the purpose of the link`
 
-### Should end in a period
+Images inside a link tag require alt text that describes the purpose of the link.
+
+Sources:
+
+- <https://axesslab.com/alt-texts/#images-in-links>
+
+### End in a period
 
 Warning: `Alt text should end in a period`
+
+End the alt-text with a period. This will make screen readers pause a bit after the last word in the alt-text, which creates a more pleasant reading experience for the user.
+
+Sources:
+
+- <https://axesslab.com/alt-texts/#end-with-a-period>
 
 ### Missing alt attribute
 
 Warning: `Missing "alt" attribute`
 
+All images must have alternate text to convey their purpose and meaning to screen reader users.
+
+Sources:
+
+- <https://dequeuniversity.com/rules/axe/3.4/image-alt>
+
 ### Alt text contains problematic words
 
 Warning: `Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>"`
+
+Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
+
+Sources:
+
+- <https://www.w3.org/WAI/tutorials/images/tips/#tips>
+- <https://axesslab.com/alt-texts/#dont-say-its-an-image>
 
 ### Alt text could be considered problematic
 
@@ -77,3 +116,10 @@ Warning: `Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|g
 ### Alt text should not start with
 
 Warning: `Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>"`
+
+Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
+
+Sources:
+
+- <https://www.w3.org/WAI/tutorials/images/tips/#tips>
+- <https://axesslab.com/alt-texts/#dont-say-its-an-image>

--- a/README.md
+++ b/README.md
@@ -42,38 +42,56 @@ console.log(altText("A screenshot of a dog"));
 
 <!-- this section is generated on commit !-->
 
+### Should not only contain a space
+
+Warning:
+
+> Alt text should not only contain a space
+
+### Character length
+
+Warning:
+
+> Alt text length should be less than 100 characters, it is currently characters.
+
 ### Image is link
 
 Warning:
 
-> Images inside a link tag require alt text that describes the purpose of the link.
+> Images inside a link tag require alt text that describes the purpose of the link
+
+### Should end in a period
+
+Warning:
+
+> Alt text should end in a period
 
 ### Missing alt attribute
 
 Warning:
 
-> Missing `alt` attribute.
+> Missing `alt` attribute
 
 ### Alt text contains problematic words
 
 Warning:
 
-> Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>".
+> Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>"
 
 ### Alt text could be considered problematic
 
 Warning:
 
-> Alt text should not be "<image|graphic|photo|photograph|placeholder|temp|alt|drawing|painting|artwork|logo|bullet|button|arrow|more|spacer|blank|chart|table|diagram|graph|\*>".
+> Alt text should not be "<image|graphic|photo|photograph|placeholder|temp|alt|drawing|painting|artwork|logo|bullet|button|arrow|more|spacer|blank|chart|table|diagram|graph|\*>"
 
 ### Alt text should not end with
 
 Warning:
 
-> Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|graphic>".
+> Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|graphic>"
 
 ### Alt text should not start with
 
 Warning:
 
-> Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>".
+> Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>"

--- a/README.md
+++ b/README.md
@@ -44,36 +44,36 @@ console.log(altText("A screenshot of a dog"));
 
 ### Image is link
 
-Error message:
+Warning:
 
 > Images inside a link tag require alt text that describes the purpose of the link.
 
 ### Missing alt attribute
 
-Error message:
+Warning:
 
 > Missing `alt` attribute.
 
 ### Alt text contains problematic words
 
-Error message:
+Warning:
 
 > Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>".
 
 ### Alt text could be considered problematic
 
-Error message:
+Warning:
 
 > Alt text should not be "<image|graphic|photo|photograph|placeholder|temp|alt|drawing|painting|artwork|logo|bullet|button|arrow|more|spacer|blank|chart|table|diagram|graph|\*>".
 
 ### Alt text should not end with
 
-Error message:
+Warning:
 
 > Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|graphic>".
 
 ### Alt text should not start with
 
-Error message:
+Warning:
 
 > Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>".

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Warning: `Alt text should end in a period`
 
 ### Missing alt attribute
 
-Warning: `Missing`alt`attribute`
+Warning: `Missing "alt" attribute`
 
 ### Alt text contains problematic words
 

--- a/README.md
+++ b/README.md
@@ -44,54 +44,36 @@ console.log(altText("A screenshot of a dog"));
 
 ### Should not only contain a space
 
-Warning:
-
-> Alt text should not only contain a space
+Warning: `Alt text should not only contain a space`
 
 ### Character length
 
-Warning:
-
-> Alt text length should be less than 100 characters, it is currently characters
+Warning: `Alt text length should be less than 100 characters, it is currently characters`
 
 ### Image is link
 
-Warning:
-
-> Images inside a link tag require alt text that describes the purpose of the link
+Warning: `Images inside a link tag require alt text that describes the purpose of the link`
 
 ### Should end in a period
 
-Warning:
-
-> Alt text should end in a period
+Warning: `Alt text should end in a period`
 
 ### Missing alt attribute
 
-Warning:
-
-> Missing `alt` attribute
+Warning: `Missing`alt`attribute`
 
 ### Alt text contains problematic words
 
-Warning:
-
-> Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>"
+Warning: `Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>"`
 
 ### Alt text could be considered problematic
 
-Warning:
-
-> Alt text should not be "<image|graphic|photo|photograph|placeholder|temp|alt|drawing|painting|artwork|logo|bullet|button|arrow|more|spacer|blank|chart|table|diagram|graph|\*>"
+Warning: `Alt text should not be "<image|graphic|photo|photograph|placeholder|temp|alt|drawing|painting|artwork|logo|bullet|button|arrow|more|spacer|blank|chart|table|diagram|graph|*>"`
 
 ### Alt text should not end with
 
-Warning:
-
-> Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|graphic>"
+Warning: `Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|graphic>"`
 
 ### Alt text should not start with
 
-Warning:
-
-> Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>"
+Warning: `Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>"`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sources:
 
 ### Character length
 
-Warning: `Alt text length should be less than 125 characters, it is currently characters`
+Warning: `Alt text length should be less than 125 characters`
 
 Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks.
 

--- a/clues.js
+++ b/clues.js
@@ -9,7 +9,9 @@ module.exports = {
   charLength: {
     heading: "Character length",
     message: length =>
-      `Alt text length should be less than 125 characters, it is currently ${length} characters`,
+      `Alt text length should be less than 125 characters${
+        length ? `, it is currently ${length} characters` : ""
+      }`,
     rationale:
       "Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks.",
     source: [

--- a/clues.js
+++ b/clues.js
@@ -1,34 +1,43 @@
 module.exports = {
   notOnlySpace: {
-    heading: "Should not only contain a space",
-    message: () => `Alt text should not only contain a space`,
-    rationale: "",
-    source: ""
+    heading: "Empty alt text",
+    message: () => `Alt text should not be a single space`,
+    rationale:
+      'If you use a null (empty) text alternative (`alt=""`) to hide decorative images, make sure that there is no space character in between the quotes. **If a space character is present, the image may not be effectively hidden from assistive technologies.** For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes.',
+    source: ["https://www.w3.org/WAI/tutorials/images/tips/#tips"]
   },
   charLength: {
     heading: "Character length",
     message: length =>
-      `Alt text length should be less than 100 characters, it is currently ${length} characters`,
-    rationale: "",
-    source: ""
+      `Alt text length should be less than 125 characters, it is currently ${length} characters`,
+    rationale:
+      "Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks.",
+    source: [
+      "https://accessibility.psu.edu/images/imageshtml/#alt",
+      "https://terrillthompson.com/tests/altlength.html"
+    ]
   },
   imageLink: {
     heading: "Image is link",
     message: () =>
       `Images inside a link tag require alt text that describes the purpose of the link`,
-    rationale: "",
-    source: ""
+    rationale:
+      "Images inside a link tag require alt text that describes the purpose of the link.",
+    source: ["https://axesslab.com/alt-texts/#images-in-links"]
   },
   endPeriod: {
-    heading: "Should end in a period",
+    heading: "End in a period",
     message: () => `Alt text should end in a period`,
-    rationale: "",
-    source: ""
+    rationale:
+      "End the alt-text with a period. This will make screen readers pause a bit after the last word in the alt-text, which creates a more pleasant reading experience for the user.",
+    source: ["https://axesslab.com/alt-texts/#end-with-a-period"]
   },
   noAlt: {
     heading: "Missing alt attribute",
     message: () => `Missing "alt" attribute`,
-    source: ""
+    rationale:
+      "All images must have alternate text to convey their purpose and meaning to screen reader users.",
+    source: ["https://dequeuniversity.com/rules/axe/3.4/image-alt"]
   },
   contains: {
     heading: "Alt text contains problematic words",
@@ -45,8 +54,12 @@ module.exports = {
       "photo:",
       "photographer:"
     ],
-    rationale: "",
-    source: ""
+    rationale:
+      "Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.",
+    source: [
+      "https://www.w3.org/WAI/tutorials/images/tips/#tips",
+      "https://axesslab.com/alt-texts/#dont-say-its-an-image"
+    ]
   },
   exactMatch: {
     heading: "Alt text could be considered problematic",
@@ -102,7 +115,6 @@ module.exports = {
     heading: "Alt text should not start with",
     fn: (item, alt) => alt.startsWith(item),
     message: value => `Alt text should not start with "${value}"`,
-
     rules: [
       "picture",
       "photo",
@@ -113,7 +125,11 @@ module.exports = {
       "screenshot",
       "spacer"
     ],
-    rationale: "",
-    source: ""
+    rationale:
+      "Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.",
+    source: [
+      "https://www.w3.org/WAI/tutorials/images/tips/#tips",
+      "https://axesslab.com/alt-texts/#dont-say-its-an-image"
+    ]
   }
 };

--- a/clues.js
+++ b/clues.js
@@ -1,33 +1,40 @@
 module.exports = {
-  "Should not only contain a space": {
+  notOnlySpace: {
+    heading: "Should not only contain a space",
     message: () => `Alt text should not only contain a space`,
     rationale: "",
     source: ""
   },
-  "Character length": {
+  charLength: {
+    heading: "Character length",
     message: length =>
-      `Alt text length should be less than 100 characters, it is currently ${length} characters.`,
+      `Alt text length should be less than 100 characters, it is currently ${length} characters`,
     rationale: "",
     source: ""
   },
-  "Image is link": {
+  imageLink: {
+    heading: "Image is link",
     message: () =>
       `Images inside a link tag require alt text that describes the purpose of the link`,
     rationale: "",
     source: ""
   },
-  "Should end in a period": {
+  endPeriod: {
+    heading: "Should end in a period",
     message: () => `Alt text should end in a period`,
     rationale: "",
     source: ""
   },
-  "Missing alt attribute": {
+  noAlt: {
+    heading: "Missing alt attribute",
     message: () => `Missing \`alt\` attribute`,
     source: ""
   },
-  "Alt text contains problematic words": {
+  contains: {
+    heading: "Alt text contains problematic words",
     fn: (item, alt) => alt.includes(item),
     message: value => `Alt text should not contain "${value}"`,
+
     rules: [
       "picture of",
       "photo of",
@@ -41,9 +48,11 @@ module.exports = {
     rationale: "",
     source: ""
   },
-  "Alt text could be considered problematic": {
+  exactMatch: {
+    heading: "Alt text could be considered problematic",
     fn: (item, alt) => item == alt.trim(),
     message: value => `Alt text should not be "${value}"`,
+
     rules: [
       "image",
       "graphic",
@@ -71,9 +80,11 @@ module.exports = {
     rationale: "",
     source: ""
   },
-  "Alt text should not end with": {
+  endWith: {
+    heading: "Alt text should not end with",
     fn: (item, alt) => alt.endsWith(item),
     message: value => `Alt text should not end with "${value}"`,
+
     rules: [
       ".jpg",
       ".jpeg",
@@ -87,9 +98,11 @@ module.exports = {
     rationale: "",
     source: ""
   },
-  "Alt text should not start with": {
+  startWith: {
+    heading: "Alt text should not start with",
     fn: (item, alt) => alt.startsWith(item),
     message: value => `Alt text should not start with "${value}"`,
+
     rules: [
       "picture",
       "photo",

--- a/clues.js
+++ b/clues.js
@@ -1,5 +1,15 @@
 module.exports = {
-  contains: {
+  "Image is link": {
+    message: () =>
+      `Images inside a link tag require alt text that describes the purpose of the link.`,
+    rationale: "",
+    source: ""
+  },
+  "Missing alt attribute": {
+    message: () => `Missing \`alt\` attribute.`,
+    source: ""
+  },
+  "Alt text contains problematic words": {
     fn: (item, alt) => alt.includes(item),
     message: value => `Alt text should not contain "${value}".`,
     rules: [
@@ -11,9 +21,11 @@ module.exports = {
       "screenshot of",
       "photo:",
       "photographer:"
-    ]
+    ],
+    rationale: "",
+    source: ""
   },
-  exactMatch: {
+  "Alt text could be considered problematic": {
     fn: (item, alt) => item == alt.trim(),
     message: value => `Alt text should not be "${value}".`,
     rules: [
@@ -39,9 +51,11 @@ module.exports = {
       "diagram",
       "graph",
       "*"
-    ]
+    ],
+    rationale: "",
+    source: ""
   },
-  endWith: {
+  "Alt text should not end with": {
     fn: (item, alt) => alt.endsWith(item),
     message: value => `Alt text should not end with "${value}".`,
     rules: [
@@ -53,9 +67,11 @@ module.exports = {
       ".webp",
       "image",
       "graphic"
-    ]
+    ],
+    rationale: "",
+    source: ""
   },
-  startWith: {
+  "Alt text should not start with": {
     fn: (item, alt) => alt.startsWith(item),
     message: value => `Alt text should not start with "${value}".`,
     rules: [
@@ -67,6 +83,8 @@ module.exports = {
       "graphic",
       "screenshot",
       "spacer"
-    ]
+    ],
+    rationale: "",
+    source: ""
   }
 };

--- a/clues.js
+++ b/clues.js
@@ -1,14 +1,14 @@
 module.exports = {
   notOnlySpace: {
     heading: "Empty alt text",
-    message: () => `Alt text should not be a single space`,
+    warning: () => `Alt text should not be a single space`,
     rationale:
       'If you use a null (empty) text alternative (`alt=""`) to hide decorative images, make sure that there is no space character in between the quotes. **If a space character is present, the image may not be effectively hidden from assistive technologies.** For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes.',
     source: ["https://www.w3.org/WAI/tutorials/images/tips/#tips"]
   },
   charLength: {
     heading: "Character length",
-    message: length =>
+    warning: length =>
       `Alt text length should be less than 125 characters${
         length ? `, it is currently ${length} characters` : ""
       }`,
@@ -21,7 +21,7 @@ module.exports = {
   },
   imageLink: {
     heading: "Image is link",
-    message: () =>
+    warning: () =>
       `Images inside a link tag require alt text that describes the purpose of the link`,
     rationale:
       "Images inside a link tag require alt text that describes the purpose of the link.",
@@ -29,14 +29,14 @@ module.exports = {
   },
   endPeriod: {
     heading: "End in a period",
-    message: () => `Alt text should end in a period`,
+    warning: () => `Alt text should end in a period`,
     rationale:
       "End the alt-text with a period. This will make screen readers pause a bit after the last word in the alt-text, which creates a more pleasant reading experience for the user.",
     source: ["https://axesslab.com/alt-texts/#end-with-a-period"]
   },
   noAlt: {
     heading: "Missing alt attribute",
-    message: () => `Missing "alt" attribute`,
+    warning: () => `Missing "alt" attribute`,
     rationale:
       "All images must have alternate text to convey their purpose and meaning to screen reader users.",
     source: ["https://dequeuniversity.com/rules/axe/3.4/image-alt"]
@@ -44,7 +44,7 @@ module.exports = {
   contains: {
     heading: "Alt text contains problematic words",
     fn: (item, alt) => alt.includes(item),
-    message: value => `Alt text should not contain "${value}"`,
+    warning: value => `Alt text should not contain "${value}"`,
 
     rules: [
       "picture of",
@@ -66,7 +66,7 @@ module.exports = {
   exactMatch: {
     heading: "Alt text could be considered problematic",
     fn: (item, alt) => item == alt.trim(),
-    message: value => `Alt text should not be "${value}"`,
+    warning: value => `Alt text should not be "${value}"`,
 
     rules: [
       "image",
@@ -98,7 +98,7 @@ module.exports = {
   endWith: {
     heading: "Alt text should not end with",
     fn: (item, alt) => alt.endsWith(item),
-    message: value => `Alt text should not end with "${value}"`,
+    warning: value => `Alt text should not end with "${value}"`,
 
     rules: [
       ".jpg",
@@ -116,7 +116,7 @@ module.exports = {
   startWith: {
     heading: "Alt text should not start with",
     fn: (item, alt) => alt.startsWith(item),
-    message: value => `Alt text should not start with "${value}"`,
+    warning: value => `Alt text should not start with "${value}"`,
     rules: [
       "picture",
       "photo",

--- a/clues.js
+++ b/clues.js
@@ -1,17 +1,33 @@
 module.exports = {
+  "Should not only contain a space": {
+    message: () => `Alt text should not only contain a space`,
+    rationale: "",
+    source: ""
+  },
+  "Character length": {
+    message: length =>
+      `Alt text length should be less than 100 characters, it is currently ${length} characters.`,
+    rationale: "",
+    source: ""
+  },
   "Image is link": {
     message: () =>
-      `Images inside a link tag require alt text that describes the purpose of the link.`,
+      `Images inside a link tag require alt text that describes the purpose of the link`,
+    rationale: "",
+    source: ""
+  },
+  "Should end in a period": {
+    message: () => `Alt text should end in a period`,
     rationale: "",
     source: ""
   },
   "Missing alt attribute": {
-    message: () => `Missing \`alt\` attribute.`,
+    message: () => `Missing \`alt\` attribute`,
     source: ""
   },
   "Alt text contains problematic words": {
     fn: (item, alt) => alt.includes(item),
-    message: value => `Alt text should not contain "${value}".`,
+    message: value => `Alt text should not contain "${value}"`,
     rules: [
       "picture of",
       "photo of",
@@ -27,7 +43,7 @@ module.exports = {
   },
   "Alt text could be considered problematic": {
     fn: (item, alt) => item == alt.trim(),
-    message: value => `Alt text should not be "${value}".`,
+    message: value => `Alt text should not be "${value}"`,
     rules: [
       "image",
       "graphic",
@@ -57,7 +73,7 @@ module.exports = {
   },
   "Alt text should not end with": {
     fn: (item, alt) => alt.endsWith(item),
-    message: value => `Alt text should not end with "${value}".`,
+    message: value => `Alt text should not end with "${value}"`,
     rules: [
       ".jpg",
       ".jpeg",
@@ -73,7 +89,7 @@ module.exports = {
   },
   "Alt text should not start with": {
     fn: (item, alt) => alt.startsWith(item),
-    message: value => `Alt text should not start with "${value}".`,
+    message: value => `Alt text should not start with "${value}"`,
     rules: [
       "picture",
       "photo",

--- a/clues.js
+++ b/clues.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   noAlt: {
     heading: "Missing alt attribute",
-    message: () => `Missing \`alt\` attribute`,
+    message: () => `Missing "alt" attribute`,
     source: ""
   },
   contains: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,11 @@
         "restore-cursor": "^3.1.0"
       }
     },
+    "cli-git.io": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli-git.io/-/cli-git.io-1.0.1.tgz",
+      "integrity": "sha512-4agvhUtkxJcumssgwSV3zuFoUhARHK8tTYSMKa/umE+1vwtxDmBytntpw3vOTEYA2qC0lBzK7EAf9F1CoJ4DAA=="
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -742,6 +747,21 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "github-slugger": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.1.tgz",
+      "integrity": "sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+        }
       }
     },
     "glob": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "url": "https://github.com/double-great/alt-text/issues"
   },
   "homepage": "https://github.com/double-great/alt-text#readme",
-  "dependencies": {},
+  "dependencies": {
+    "cli-git.io": "^1.0.1",
+    "github-slugger": "^1.2.1"
+  },
   "devDependencies": {
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
@@ -30,7 +33,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "node scripts/write-docs.js && git add README.md && pretty-quick --staged"
+      "pre-commit": "node scripts/write-docs.js && git add README.md && pretty-quick --staged && node scripts/url.js"
     }
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint . --fix",
     "pretest": "npm run lint",
     "test": "tape tests/*.test.js",
-    "pretty-quick": "pretty-quick"
+    "pretty-quick": "pretty-quick",
+    "write-docs": "node scripts/write-docs.js"
   },
   "repository": {
     "type": "git",
@@ -33,7 +34,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "node scripts/write-docs.js && git add README.md && pretty-quick --staged && node scripts/url.js"
+      "pre-commit": "npm run write-docs && git add README.md && pretty-quick --staged && node scripts/url.js"
     }
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "node scripts/write-docs.js && git add README.md && pretty-quick --staged"
     }
   },
   "directories": {

--- a/rules.js
+++ b/rules.js
@@ -21,7 +21,7 @@ function checkClue(alt) {
 }
 
 function checkLength(alt) {
-  return alt.length > 100 ? [createWarning("charLength", alt.length)] : [];
+  return alt.length > 125 ? [createWarning("charLength", alt.length)] : [];
 }
 
 function checkOnlySpace(alt) {

--- a/rules.js
+++ b/rules.js
@@ -2,7 +2,7 @@ const clues = require("./clues");
 const urls = require("./urls");
 
 function createWarning(ruleName, value) {
-  return `${clues[ruleName].message(value)} (${urls[ruleName]}).`;
+  return `${clues[ruleName].warning(value)} (${urls[ruleName]}).`;
 }
 
 function filterClues(ruleName, clue, alt) {

--- a/rules.js
+++ b/rules.js
@@ -9,7 +9,7 @@ function filterClues(clue, alt) {
 
 function checkClue(alt) {
   return Object.keys(clues).reduce((arr, item) => {
-    arr = [...arr, ...filterClues(clues[item], alt)];
+    if (clues[item].rules) arr = [...arr, ...filterClues(clues[item], alt)];
     return arr;
   }, []);
 }

--- a/rules.js
+++ b/rules.js
@@ -21,18 +21,16 @@ function checkClue(alt) {
 }
 
 function checkLength(alt) {
-  return alt.length > 100
-    ? [createWarning("Character length", alt.length)]
-    : [];
+  return alt.length > 100 ? [createWarning("charLength", alt.length)] : [];
 }
 
 function checkOnlySpace(alt) {
-  return alt == " " ? [createWarning("Should not only contain a space")] : [];
+  return alt == " " ? [createWarning("notOnlySpace")] : [];
 }
 
 function checkPeriod(alt) {
   return !alt.endsWith(".") && alt.length > 1
-    ? [createWarning("Should end in a period")]
+    ? [createWarning("endPeriod")]
     : [];
 }
 

--- a/rules.js
+++ b/rules.js
@@ -1,34 +1,38 @@
 const clues = require("./clues");
+const urls = require("./urls");
 
-function filterClues(clue, alt) {
+function createWarning(ruleName, value) {
+  return `${clues[ruleName].message(value)} (${urls[ruleName]}).`;
+}
+
+function filterClues(ruleName, clue, alt) {
   return clue.rules.reduce((arr, item) => {
-    if (clue.fn(item, alt)) arr.push(clue.message(item));
+    if (clue.fn(item, alt)) arr.push(createWarning(ruleName, item));
     return arr;
   }, []);
 }
 
 function checkClue(alt) {
   return Object.keys(clues).reduce((arr, item) => {
-    if (clues[item].rules) arr = [...arr, ...filterClues(clues[item], alt)];
+    if (clues[item].rules)
+      arr = [...arr, ...filterClues(item, clues[item], alt)];
     return arr;
   }, []);
 }
 
 function checkLength(alt) {
   return alt.length > 100
-    ? [
-        `Alt text length should be less than 100 characters, it is currently ${alt.length} characters.`
-      ]
+    ? [createWarning("Character length", alt.length)]
     : [];
 }
 
 function checkOnlySpace(alt) {
-  return alt == " " ? ["Alt text must not only contain a space."] : [];
+  return alt == " " ? [createWarning("Should not only contain a space")] : [];
 }
 
 function checkPeriod(alt) {
   return !alt.endsWith(".") && alt.length > 1
-    ? ["Alt text should end in a period."]
+    ? [createWarning("Should end in a period")]
     : [];
 }
 

--- a/scripts/url.js
+++ b/scripts/url.js
@@ -1,0 +1,37 @@
+const githubURL = require("cli-git.io");
+const clues = require("../clues");
+const fs = require("fs");
+const GithubSlugger = require("github-slugger");
+const slugger = new GithubSlugger();
+
+const getUrl = url => {
+  return new Promise(resolve => {
+    githubURL.shorten(url, shortURL => {
+      resolve(shortURL);
+    });
+  });
+};
+
+const shortenUrls = async () => {
+  const obj = {};
+  await Promise.all(
+    Object.keys(clues).map(async clue => {
+      const url = `https://github.com/double-great/alt-text#${slugger.slug(
+        clue
+      )}`;
+      const shortendUrl = await getUrl(url);
+      obj[clue] = shortendUrl;
+    })
+  );
+
+  const sorted = Object.keys(obj)
+    .sort()
+    .reduce((o, i) => {
+      o[i] = obj[i];
+      return o;
+    }, {});
+
+  fs.writeFileSync("urls.json", `${JSON.stringify(sorted, null, 2)}\n`);
+};
+
+shortenUrls();

--- a/scripts/url.js
+++ b/scripts/url.js
@@ -17,7 +17,7 @@ const shortenUrls = async () => {
   await Promise.all(
     Object.keys(clues).map(async clue => {
       const url = `https://github.com/double-great/alt-text#${slugger.slug(
-        clue
+        clues[clue].heading
       )}`;
       const shortendUrl = await getUrl(url);
       obj[clue] = shortendUrl;

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -5,7 +5,7 @@ const md = Object.keys(clues).reduce((str, clue) => {
   const options = clues[clue].rules ? `<${clues[clue].rules.join("|")}>` : "";
 
   str += `### ${clues[clue].heading}\n\n`;
-  str += `Warning:\n\n> ${clues[clue].message(options)}`;
+  str += `Warning: \`${clues[clue].message(options)}\``;
 
   str += "\n\n";
   if (clues[clue].rationale) str += `${clues[clue].rationale}\n\n`;

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -5,7 +5,7 @@ const md = Object.keys(clues).reduce((str, clue) => {
   const options = clues[clue].rules ? `<${clues[clue].rules.join("|")}>` : "";
 
   str += `### ${clue}\n\n`;
-  str += `Error message:\n\n> ${clues[clue].message(options)}`;
+  str += `Warning:\n\n> ${clues[clue].message(options)}`;
 
   str += "\n\n";
   if (clues[clue].rationale) str += `${clues[clue].rationale}\n\n`;

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -9,7 +9,7 @@ const md = Object.keys(clues).reduce((str, clue) => {
 
   str += "\n\n";
   if (clues[clue].rationale) str += `${clues[clue].rationale}\n\n`;
-  if (clues[clue].source) str += `Source: ${clues[clue].source}\n\n`;
+  if (clues[clue].source) str += `Source: <${clues[clue].source}>\n\n`;
   return str;
 }, "## Warnings\n\n<!-- this section is generated on commit !-->\n\n");
 

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -2,8 +2,12 @@ const fs = require("fs");
 const clues = require("../clues");
 
 const md = Object.keys(clues).reduce((str, clue) => {
+  const options = clues[clue].rules ? `<${clues[clue].rules.join("|")}>` : "";
+
   str += `### ${clue}\n\n`;
-  str += `Error message:\n\n> ${clues[clue].message("x")}\n\n`;
+  str += `Error message:\n\n> ${clues[clue].message(options)}`;
+
+  str += "\n\n";
   if (clues[clue].rationale) str += `${clues[clue].rationale}\n\n`;
   if (clues[clue].source) str += `Source: ${clues[clue].source}\n\n`;
   return str;

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const clues = require("../clues");
+
+const md = Object.keys(clues).reduce((str, clue) => {
+  str += `### ${clue}\n\n`;
+  str += `Error message:\n\n> ${clues[clue].message("x")}\n\n`;
+  if (clues[clue].rationale) str += `${clues[clue].rationale}\n\n`;
+  if (clues[clue].source) str += `Source: ${clues[clue].source}\n\n`;
+  return str;
+}, "## Warnings\n\n<!-- this section is generated on commit !-->\n\n");
+
+const readme = fs.readFileSync("readme.md", "utf-8");
+const regex = /## Warnings([\s\S]*)/g;
+const oldFile = readme.match(regex);
+const newFile = readme.replace(oldFile, md);
+
+fs.writeFileSync("README.md", newFile);

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -4,7 +4,7 @@ const clues = require("../clues");
 const md = Object.keys(clues).reduce((str, clue) => {
   const options = clues[clue].rules ? `<${clues[clue].rules.join("|")}>` : "";
 
-  str += `### ${clue}\n\n`;
+  str += `### ${clues[clue].heading}\n\n`;
   str += `Warning:\n\n> ${clues[clue].message(options)}`;
 
   str += "\n\n";

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -2,10 +2,10 @@ const fs = require("fs");
 const clues = require("../clues");
 
 const md = Object.keys(clues).reduce((str, clue) => {
-  const { message, rationale, source, heading, rules } = clues[clue];
+  const { warning, rationale, source, heading, rules } = clues[clue];
   const options = rules ? `<${rules.join("|")}>` : "";
   str += `### ${heading}\n\n`;
-  str += `Warning: \`${message(options)}\``;
+  str += `Warning: \`${warning(options)}\``;
   str += "\n\n";
   if (rationale) str += `${rationale}\n\n`;
   if (source)

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -2,14 +2,14 @@ const fs = require("fs");
 const clues = require("../clues");
 
 const md = Object.keys(clues).reduce((str, clue) => {
-  const options = clues[clue].rules ? `<${clues[clue].rules.join("|")}>` : "";
-
-  str += `### ${clues[clue].heading}\n\n`;
-  str += `Warning: \`${clues[clue].message(options)}\``;
-
+  const { message, rationale, source, heading, rules } = clues[clue];
+  const options = rules ? `<${rules.join("|")}>` : "";
+  str += `### ${heading}\n\n`;
+  str += `Warning: \`${message(options)}\``;
   str += "\n\n";
-  if (clues[clue].rationale) str += `${clues[clue].rationale}\n\n`;
-  if (clues[clue].source) str += `Source: <${clues[clue].source}>\n\n`;
+  if (rationale) str += `${rationale}\n\n`;
+  if (source)
+    str += `Sources:\n${source.map(link => `- <${link}>\n`).join("")}\n`;
   return str;
 }, "## Warnings\n\n<!-- this section is generated on commit !-->\n\n");
 

--- a/tests/clues.test.js
+++ b/tests/clues.test.js
@@ -13,6 +13,23 @@ Object.keys(clues).forEach(clue => {
       "function",
       "value of `message` is a function"
     );
+    assert.equal(
+      clues[clue].message().endsWith("."),
+      false,
+      "`message` must not end in period"
+    );
+
+    /*
+    assert.ok(
+      clues[clue].source,
+      "must have `source`"
+    );
+    assert.ok(
+      clues[clue].rationale,
+      "must have `rationale`"
+    );
+    */
+    assert.ok(clues[clue].heading, "must have `heading`");
     if (clues[clue].fn) {
       assert.equal(
         typeof clues[clue].fn,

--- a/tests/clues.test.js
+++ b/tests/clues.test.js
@@ -9,23 +9,28 @@ test("[clues]", assert => {
 Object.keys(clues).forEach(clue => {
   test(`[clues] ${clue}`, assert => {
     assert.equal(
-      typeof clues[clue].fn,
-      "function",
-      "value of `fn` is a function"
-    );
-    assert.equal(
       typeof clues[clue].message,
       "function",
       "value of `message` is a function"
     );
-    assert.equal(
-      typeof clues[clue].rules,
-      "object",
-      "value of `rules` is an object (array)"
-    );
-    clues[clue].rules.forEach(rule => {
-      assert.equal(rule, rule.toLowerCase(), `"${rule}" must be lowercase`);
-    });
+    if (clues[clue].fn) {
+      assert.equal(
+        typeof clues[clue].fn,
+        "function",
+        "value of `fn` is a function"
+      );
+    }
+    if (clues[clue].rules) {
+      assert.equal(
+        typeof clues[clue].rules,
+        "object",
+        "value of `rules` is an object (array)"
+      );
+      clues[clue].rules.forEach(rule => {
+        assert.equal(rule, rule.toLowerCase(), `"${rule}" must be lowercase`);
+      });
+    }
+
     assert.end();
   });
 });

--- a/tests/clues.test.js
+++ b/tests/clues.test.js
@@ -9,14 +9,14 @@ test("[clues]", assert => {
 Object.keys(clues).forEach(clue => {
   test(`[clues] ${clue}`, assert => {
     assert.equal(
-      typeof clues[clue].message,
+      typeof clues[clue].warning,
       "function",
-      "value of `message` is a function"
+      "value of `warning` is a function"
     );
     assert.equal(
-      clues[clue].message().endsWith("."),
+      clues[clue].warning().endsWith("."),
       false,
-      "`message` must not end in period"
+      "`warning` must not end in period"
     );
 
     /*

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -20,12 +20,12 @@ test("[altText] return warnings", assert => {
 
   assert.equal(
     altText("A SCREENSHOT OF A DOG"),
-    'Alt text should not contain "screenshot of" (https://git.io/JvfAe). Alt text should end in a period (https://git.io/JvfxY).',
+    'Alt text should not contain "screenshot of" (https://git.io/JvfAe). Alt text should end in a period (https://git.io/Jvqiq).',
     "more than one warning"
   );
   assert.equal(
     altText("An inhaler with a spacer connected to the mouthpiece"),
-    "Alt text should end in a period (https://git.io/JvfxY)."
+    "Alt text should end in a period (https://git.io/Jvqiq)."
   );
   assert.end();
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -14,18 +14,18 @@ test("[altText] return no warning", assert => {
 test("[altText] return warnings", assert => {
   assert.equal(
     altText("A SCREENSHOT OF A DOG."),
-    'Alt text should not contain "screenshot of".',
+    'Alt text should not contain "screenshot of" (https://git.io/JvfAe).',
     "alt text rules are case insensitive"
   );
 
   assert.equal(
     altText("A SCREENSHOT OF A DOG"),
-    'Alt text should not contain "screenshot of". Alt text should end in a period.',
+    'Alt text should not contain "screenshot of" (https://git.io/JvfAe). Alt text should end in a period (https://git.io/JvfxY).',
     "more than one warning"
   );
   assert.equal(
     altText("An inhaler with a spacer connected to the mouthpiece"),
-    "Alt text should end in a period."
+    "Alt text should end in a period (https://git.io/JvfxY)."
   );
   assert.end();
 });

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -5,49 +5,51 @@ test("[rules] checkClue.endWith", assert => {
   assert.deepEqual(
     rules.checkClue("A screenshot of a dog.jpg"),
     [
-      'Alt text should not contain "screenshot of".',
-      'Alt text should not end with ".jpg".'
+      'Alt text should not contain "screenshot of" (https://git.io/JvfAe).',
+      'Alt text should not end with ".jpg" (https://git.io/JvfAf).'
     ],
     "can have more than one warning"
   );
   assert.deepEqual(rules.checkClue("DSC_0010.jpg"), [
-    'Alt text should not end with ".jpg".'
+    'Alt text should not end with ".jpg" (https://git.io/JvfAf).'
   ]);
   assert.deepEqual(rules.checkClue("placeholder graphic"), [
-    'Alt text should not end with "graphic".'
+    'Alt text should not end with "graphic" (https://git.io/JvfAf).'
   ]);
   assert.end();
 });
 
 test("[rules] checkClue.startWith", assert => {
   assert.deepEqual(rules.checkClue("spacer image."), [
-    'Alt text should not start with "spacer".'
+    'Alt text should not start with "spacer" (https://git.io/JvfAv).'
   ]);
   assert.end();
 });
 
 test("[rules] checkClue.exactMatch", assert => {
-  assert.deepEqual(rules.checkClue("logo"), ['Alt text should not be "logo".']);
+  assert.deepEqual(rules.checkClue("logo"), [
+    'Alt text should not be "logo" (https://git.io/JvfAJ).'
+  ]);
   assert.end();
 });
 
 test("[rules] checkClue.exactMatch", assert => {
   assert.deepEqual(rules.checkClue(" logo "), [
-    'Alt text should not be "logo".'
+    'Alt text should not be "logo" (https://git.io/JvfAJ).'
   ]);
   assert.end();
 });
 
 test("[rules] checkClue.contain", assert => {
   assert.deepEqual(rules.checkClue("A screenshot of a dog."), [
-    'Alt text should not contain "screenshot of".'
+    'Alt text should not contain "screenshot of" (https://git.io/JvfAe).'
   ]);
   assert.end();
 });
 
 test("[rules] checkPeriod", assert => {
   assert.deepEqual(rules.checkPeriod("a large black dog"), [
-    "Alt text should end in a period."
+    "Alt text should end in a period (https://git.io/JvfxY)."
   ]);
   assert.end();
 });
@@ -58,7 +60,7 @@ test("[rules] checkLength", assert => {
       "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
     ),
     [
-      "Alt text length should be less than 100 characters, it is currently 446 characters."
+      "Alt text length should be less than 100 characters, it is currently 446 characters. (https://git.io/Jvfxm)."
     ]
   );
   assert.end();
@@ -66,7 +68,7 @@ test("[rules] checkLength", assert => {
 
 test("[rules] checkOnlySpace", assert => {
   assert.deepEqual(rules.checkOnlySpace(" "), [
-    "Alt text must not only contain a space."
+    "Alt text should not only contain a space (https://git.io/JvfxO)."
   ]);
   assert.end();
 });

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -60,7 +60,7 @@ test("[rules] checkLength", assert => {
       "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
     ),
     [
-      "Alt text length should be less than 100 characters, it is currently 446 characters. (https://git.io/Jvfxm)."
+      "Alt text length should be less than 100 characters, it is currently 446 characters (https://git.io/Jvfxm)."
     ]
   );
   assert.end();

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -49,7 +49,7 @@ test("[rules] checkClue.contain", assert => {
 
 test("[rules] checkPeriod", assert => {
   assert.deepEqual(rules.checkPeriod("a large black dog"), [
-    "Alt text should end in a period (https://git.io/JvfxY)."
+    "Alt text should end in a period (https://git.io/Jvqiq)."
   ]);
   assert.end();
 });
@@ -68,7 +68,7 @@ test("[rules] checkLength", assert => {
 
 test("[rules] checkOnlySpace", assert => {
   assert.deepEqual(rules.checkOnlySpace(" "), [
-    "Alt text should not be a single space (https://git.io/JvfxO)."
+    "Alt text should not be a single space (https://git.io/Jvqim)."
   ]);
   assert.end();
 });

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -60,7 +60,7 @@ test("[rules] checkLength", assert => {
       "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
     ),
     [
-      "Alt text length should be less than 100 characters, it is currently 446 characters (https://git.io/Jvfxm)."
+      "Alt text length should be less than 125 characters, it is currently 446 characters (https://git.io/Jvfxm)."
     ]
   );
   assert.end();
@@ -68,7 +68,7 @@ test("[rules] checkLength", assert => {
 
 test("[rules] checkOnlySpace", assert => {
   assert.deepEqual(rules.checkOnlySpace(" "), [
-    "Alt text should not only contain a space (https://git.io/JvfxO)."
+    "Alt text should not be a single space (https://git.io/JvfxO)."
   ]);
   assert.end();
 });

--- a/urls.json
+++ b/urls.json
@@ -1,11 +1,11 @@
 {
   "charLength": "https://git.io/Jvfxm",
   "contains": "https://git.io/JvfAe",
-  "endPeriod": "https://git.io/JvfxY",
+  "endPeriod": "https://git.io/Jvqiq",
   "endWith": "https://git.io/JvfAf",
   "exactMatch": "https://git.io/JvfAJ",
   "imageLink": "https://git.io/JvfNj",
   "noAlt": "https://git.io/JvfNh",
-  "notOnlySpace": "https://git.io/JvfxO",
+  "notOnlySpace": "https://git.io/Jvqim",
   "startWith": "https://git.io/JvfAv"
 }

--- a/urls.json
+++ b/urls.json
@@ -1,11 +1,11 @@
 {
-  "Alt text contains problematic words": "https://git.io/JvfAe",
-  "Alt text could be considered problematic": "https://git.io/JvfAJ",
-  "Alt text should not end with": "https://git.io/JvfAf",
-  "Alt text should not start with": "https://git.io/JvfAv",
-  "Character length": "https://git.io/Jvfxm",
-  "Image is link": "https://git.io/JvfNj",
-  "Missing alt attribute": "https://git.io/JvfNh",
-  "Should end in a period": "https://git.io/JvfxY",
-  "Should not only contain a space": "https://git.io/JvfxO"
+  "charLength": "https://git.io/Jvfxm",
+  "contains": "https://git.io/JvfAe",
+  "endPeriod": "https://git.io/JvfxY",
+  "endWith": "https://git.io/JvfAf",
+  "exactMatch": "https://git.io/JvfAJ",
+  "imageLink": "https://git.io/JvfNj",
+  "noAlt": "https://git.io/JvfNh",
+  "notOnlySpace": "https://git.io/JvfxO",
+  "startWith": "https://git.io/JvfAv"
 }

--- a/urls.json
+++ b/urls.json
@@ -1,0 +1,11 @@
+{
+  "Alt text contains problematic words": "https://git.io/JvfAe",
+  "Alt text could be considered problematic": "https://git.io/JvfAJ",
+  "Alt text should not end with": "https://git.io/JvfAf",
+  "Alt text should not start with": "https://git.io/JvfAv",
+  "Character length": "https://git.io/Jvfxm",
+  "Image is link": "https://git.io/JvfNj",
+  "Missing alt attribute": "https://git.io/JvfNh",
+  "Should end in a period": "https://git.io/JvfxY",
+  "Should not only contain a space": "https://git.io/JvfxO"
+}


### PR DESCRIPTION
This PR sketches out what documentation around warnings could look like:

* Reworked clues.js:
  - key name is now the title/heading of the clue
  - added `rationale` and `source` keys to store an explanation of each warning and the source of the information
  - added rules around links (to be imported in remark-lint-alt-text)
* Created scripts/write-docs.js:
  - on commit, this file will compile the warnings from clue.js and overwrite the Warnings section in the README
* Move all rules to clues.js
* Created scripts.urls.js:
  - on commit, this file will generate a shortened url to each anchor link and then create urls.json

To do:
* [x] Get copyedits from @jsnmrs on clue `heading`s 
* [x] Add `rationale` and `source` to each clue
* [x] Figure out where in the build process to use https://git.io/ to create a tiny url for each warning and add to warning message so the user can follow the link to learn more about the warning.