### PR TITLE
Add `ok` and `notOk` examples to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Sources:
 Warning: `Images inside a link tag require alt text that describes the purpose of the link`
 
 - ✅ `<a href="https://github.com/double-great"><img src="logo.png" alt="double great on github.com" /></a>`
-- 🚫`<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo" /></a>`
+- 🚫 `<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo" /></a>`
 
 Images inside a link tag require alt text that describes the purpose of the link.
 
@@ -81,6 +81,9 @@ Sources:
 
 Warning: `Alt text should end in a period`
 
+- ✅ A child holding a photograph.
+- 🚫 A child holding a photograph
+
 End the alt-text with a period. This will make screen readers pause a bit after the last word in the alt-text, which creates a more pleasant reading experience for the user.
 
 Sources:
@@ -91,6 +94,9 @@ Sources:
 
 Warning: `Missing "alt" attribute`
 
+- ✅ `<img src="photograph.png" alt="A child holding a photograph." />`
+- 🚫 `<img src="photograph.png" />`
+
 All images must have alternate text to convey their purpose and meaning to screen reader users.
 
 Sources:
@@ -100,6 +106,9 @@ Sources:
 ### Alt text contains problematic words
 
 Warning: `Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>"`
+
+- ✅ A child holding a photograph.
+- 🚫 A picture of a child holding a photograph.
 
 Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
 
@@ -112,13 +121,22 @@ Sources:
 
 Warning: `Alt text should not be "<image|graphic|photo|photograph|placeholder|temp|alt|drawing|painting|artwork|logo|bullet|button|arrow|more|spacer|blank|chart|table|diagram|graph|*>"`
 
+- ✅ A child holding a photograph.
+- 🚫 photograph
+
 ### Alt text should not end with
 
 Warning: `Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|graphic>"`
 
+- ✅ A child holding a photograph.
+- 🚫 photograph.jpg
+
 ### Alt text should not start with
 
 Warning: `Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>"`
+
+- ✅ A child holding a photograph.
+- 🚫 Image of a child.
 
 Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Sources:
 Warning: `Images inside a link tag require alt text that describes the purpose of the link`
 
 - ✅ `<a href="https://github.com/double-great"><img src="logo.png" alt="double great on github.com" /></a>`
-- 🚫`<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo" /></a>`Images inside a link tag require alt text that describes the purpose of the link.
+- 🚫`<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo" /></a>`
+
+Images inside a link tag require alt text that describes the purpose of the link.
 
 Sources:
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Sources:
 
 Warning: `Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>"`
 
-- ✅ A child holding a photograph.
-- 🚫 A picture of a child holding a photograph.
+- ✅ Dog jumping through a hoop.
+- 🚫 Image of a dog jumping through a hoop.
 
 Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ console.log(altText("A screenshot of a dog"));
 
 Warning: `Alt text should not be a single space`
 
+If you use a null (empty) text alternative (`alt=""`) to hide decorative images, make sure that there is no space character in between the quotes. **If a space character is present, the image may not be effectively hidden from assistive technologies.** For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes.
+
 - ✅ `<img src="photo.png" alt="" />`
 - 🚫 `<img src="photo.png" alt=" " />`
-
-If you use a null (empty) text alternative (`alt=""`) to hide decorative images, make sure that there is no space character in between the quotes. **If a space character is present, the image may not be effectively hidden from assistive technologies.** For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes.
 
 Sources:
 
@@ -60,10 +60,10 @@ Sources:
 
 Warning: `Alt text length should be less than 125 characters`
 
+Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks. Any information about the image, such as copyright information, image source or extra information should be placed in the caption text below the image.
+
 - ✅ George Washington and Lafayette on horseback talking to soldiers in snow at Valley Forge.
 - 🚫 Caption: Painting "Washington and Lafayette at Valley Forge" by John Ward Dunsmore from 1907. Image courtesy of the Library of Congress.
-
-Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks. Any information about the image, such as copyright information, image source or extra information should be placed in the caption text below the image.
 
 Sources:
 
@@ -74,10 +74,10 @@ Sources:
 
 Warning: `Images inside a link tag require alt text that describes the purpose of the link`
 
+Images inside a link tag require alt text that describes the purpose of the link.
+
 - ✅ `<a href="https://github.com/double-great"><img src="logo.png" alt="double great on github.com" /></a>`
 - 🚫 `<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo" /></a>`
-
-Images inside a link tag require alt text that describes the purpose of the link.
 
 Sources:
 
@@ -87,10 +87,10 @@ Sources:
 
 Warning: `Alt text should end in a period`
 
+End the alt-text with a period. This will make screen readers pause a bit after the last word in the alt-text, which creates a more pleasant reading experience for the user.
+
 - ✅ A child holding a photograph.
 - 🚫 A child holding a photograph
-
-End the alt-text with a period. This will make screen readers pause a bit after the last word in the alt-text, which creates a more pleasant reading experience for the user.
 
 Sources:
 
@@ -100,10 +100,10 @@ Sources:
 
 Warning: `Missing "alt" attribute`
 
+All images must have alternate text to convey their purpose and meaning to screen reader users.
+
 - ✅ `<img src="photograph.png" alt="A child holding a photograph." />`
 - 🚫 `<img src="photograph.png" />`
-
-All images must have alternate text to convey their purpose and meaning to screen reader users.
 
 Sources:
 
@@ -113,10 +113,10 @@ Sources:
 
 Warning: `Alt text should not contain "<picture of|photo of|photograph of|image of|graphic of|screenshot of|photo:|photographer:>"`
 
+Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
+
 - ✅ Dog jumping through a hoop.
 - 🚫 Image of a dog jumping through a hoop.
-
-Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
 
 Sources:
 
@@ -141,10 +141,10 @@ Warning: `Alt text should not end with "<.jpg|.jpeg|.gif|.png|.svg|.webp|image|g
 
 Warning: `Alt text should not start with "<picture|photo|photograph|photographer|image|graphic|screenshot|spacer>"`
 
+Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
+
 - ✅ A child holding a photograph.
 - 🚫 Image of a child.
-
-Usually, there’s no need to include words like “image”, “icon”, or “picture” in the alt text. People who can see will know this already, and screen readers announce the presence of an image.
 
 Sources:
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ console.log(altText("A screenshot of a dog"));
 
 Warning: `Alt text should not be a single space`
 
+- ✅ `<img src="photo.png" alt="" />`
+- 🚫 `<img src="photo.png" alt=" " />`
+
 If you use a null (empty) text alternative (`alt=""`) to hide decorative images, make sure that there is no space character in between the quotes. **If a space character is present, the image may not be effectively hidden from assistive technologies.** For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes.
 
 Sources:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ Sources:
 
 Warning: `Alt text length should be less than 125 characters`
 
-Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks.
+- ✅ George Washington and Lafayette on horseback talking to soldiers in snow at Valley Forge.
+- 🚫 Caption: Painting "Washington and Lafayette at Valley Forge" by John Ward Dunsmore from 1907. Image courtesy of the Library of Congress.
+
+Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks. Any information about the image, such as copyright information, image source or extra information should be placed in the caption text below the image.
 
 Sources:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Sources:
 
 Warning: `Images inside a link tag require alt text that describes the purpose of the link`
 
-Images inside a link tag require alt text that describes the purpose of the link.
+- ✅ `<a href="https://github.com/double-great"><img src="logo.png" alt="double great on github.com" /></a>`
+- 🚫`<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo" /></a>`Images inside a link tag require alt text that describes the purpose of the link.
 
 Sources:
 

--- a/clues.js
+++ b/clues.js
@@ -25,7 +25,11 @@ module.exports = {
       `Images inside a link tag require alt text that describes the purpose of the link`,
     rationale:
       "Images inside a link tag require alt text that describes the purpose of the link.",
-    source: ["https://axesslab.com/alt-texts/#images-in-links"]
+    source: ["https://axesslab.com/alt-texts/#images-in-links"],
+    ok:
+      '`<a href="https://github.com/double-great"><img src="logo.png" alt="double great on github.com" /></a>`',
+    notOk:
+      '`<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo" /></a>`'
   },
   endPeriod: {
     heading: "End in a period",

--- a/clues.js
+++ b/clues.js
@@ -36,20 +36,23 @@ module.exports = {
     warning: () => `Alt text should end in a period`,
     rationale:
       "End the alt-text with a period. This will make screen readers pause a bit after the last word in the alt-text, which creates a more pleasant reading experience for the user.",
-    source: ["https://axesslab.com/alt-texts/#end-with-a-period"]
+    source: ["https://axesslab.com/alt-texts/#end-with-a-period"],
+    ok: "A child holding a photograph.",
+    notOk: "A child holding a photograph"
   },
   noAlt: {
     heading: "Missing alt attribute",
     warning: () => `Missing "alt" attribute`,
     rationale:
       "All images must have alternate text to convey their purpose and meaning to screen reader users.",
-    source: ["https://dequeuniversity.com/rules/axe/3.4/image-alt"]
+    source: ["https://dequeuniversity.com/rules/axe/3.4/image-alt"],
+    ok: '`<img src="photograph.png" alt="A child holding a photograph." />`',
+    notOk: '`<img src="photograph.png" />`'
   },
   contains: {
     heading: "Alt text contains problematic words",
     fn: (item, alt) => alt.includes(item),
     warning: value => `Alt text should not contain "${value}"`,
-
     rules: [
       "picture of",
       "photo of",
@@ -65,13 +68,14 @@ module.exports = {
     source: [
       "https://www.w3.org/WAI/tutorials/images/tips/#tips",
       "https://axesslab.com/alt-texts/#dont-say-its-an-image"
-    ]
+    ],
+    ok: "A child holding a photograph.",
+    notOk: "A picture of a child holding a photograph."
   },
   exactMatch: {
     heading: "Alt text could be considered problematic",
     fn: (item, alt) => item == alt.trim(),
     warning: value => `Alt text should not be "${value}"`,
-
     rules: [
       "image",
       "graphic",
@@ -97,13 +101,14 @@ module.exports = {
       "*"
     ],
     rationale: "",
-    source: ""
+    source: "",
+    ok: "A child holding a photograph.",
+    notOk: "photograph"
   },
   endWith: {
     heading: "Alt text should not end with",
     fn: (item, alt) => alt.endsWith(item),
     warning: value => `Alt text should not end with "${value}"`,
-
     rules: [
       ".jpg",
       ".jpeg",
@@ -115,7 +120,9 @@ module.exports = {
       "graphic"
     ],
     rationale: "",
-    source: ""
+    source: "",
+    ok: "A child holding a photograph.",
+    notOk: "photograph.jpg"
   },
   startWith: {
     heading: "Alt text should not start with",
@@ -136,6 +143,8 @@ module.exports = {
     source: [
       "https://www.w3.org/WAI/tutorials/images/tips/#tips",
       "https://axesslab.com/alt-texts/#dont-say-its-an-image"
-    ]
+    ],
+    ok: "A child holding a photograph.",
+    notOk: "Image of a child."
   }
 };

--- a/clues.js
+++ b/clues.js
@@ -15,11 +15,15 @@ module.exports = {
         length ? `, it is currently ${length} characters` : ""
       }`,
     rationale:
-      "Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks.",
+      "Alt text should be less than 125 characters in length. The JAWS screen reader reads alt text in 125 character chunks. Any information about the image, such as copyright information, image source or extra information should be placed in the caption text below the image.",
     source: [
       "https://accessibility.psu.edu/images/imageshtml/#alt",
       "https://terrillthompson.com/tests/altlength.html"
-    ]
+    ],
+    ok:
+      "George Washington and Lafayette on horseback talking to soldiers in snow at Valley Forge.",
+    notOk:
+      'Caption: Painting "Washington and Lafayette at Valley Forge" by John Ward Dunsmore from 1907. Image courtesy of the Library of Congress.'
   },
   imageLink: {
     heading: "Image is link",

--- a/clues.js
+++ b/clues.js
@@ -4,7 +4,9 @@ module.exports = {
     warning: () => `Alt text should not be a single space`,
     rationale:
       'If you use a null (empty) text alternative (`alt=""`) to hide decorative images, make sure that there is no space character in between the quotes. **If a space character is present, the image may not be effectively hidden from assistive technologies.** For instance, some screen readers will still announce the presence of an image if a space character is put between the quotes.',
-    source: ["https://www.w3.org/WAI/tutorials/images/tips/#tips"]
+    source: ["https://www.w3.org/WAI/tutorials/images/tips/#tips"],
+    ok: '`<img src="photo.png" alt="" />`',
+    notOk: '`<img src="photo.png" alt=" " />`'
   },
   charLength: {
     heading: "Character length",

--- a/clues.js
+++ b/clues.js
@@ -75,8 +75,8 @@ module.exports = {
       "https://www.w3.org/WAI/tutorials/images/tips/#tips",
       "https://axesslab.com/alt-texts/#dont-say-its-an-image"
     ],
-    ok: "A child holding a photograph.",
-    notOk: "A picture of a child holding a photograph."
+    ok: "Dog jumping through a hoop.",
+    notOk: "Image of a dog jumping through a hoop."
   },
   exactMatch: {
     heading: "Alt text could be considered problematic",

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -7,8 +7,8 @@ const md = Object.keys(clues).reduce((str, clue) => {
   str += `### ${heading}\n\n`;
   str += `Warning: \`${warning(options)}\``;
   str += "\n\n";
-  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫 ${notOk}\n\n`;
   if (rationale) str += `${rationale}\n\n`;
+  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫 ${notOk}\n\n`;
   if (source)
     str += `Sources:\n${source.map(link => `- <${link}>\n`).join("")}\n`;
   return str;

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -2,11 +2,12 @@ const fs = require("fs");
 const clues = require("../clues");
 
 const md = Object.keys(clues).reduce((str, clue) => {
-  const { warning, rationale, source, heading, rules } = clues[clue];
+  const { warning, rationale, source, heading, rules, ok, notOk } = clues[clue];
   const options = rules ? `<${rules.join("|")}>` : "";
   str += `### ${heading}\n\n`;
   str += `Warning: \`${warning(options)}\``;
   str += "\n\n";
+  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫${notOk}`;
   if (rationale) str += `${rationale}\n\n`;
   if (source)
     str += `Sources:\n${source.map(link => `- <${link}>\n`).join("")}\n`;

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -7,7 +7,7 @@ const md = Object.keys(clues).reduce((str, clue) => {
   str += `### ${heading}\n\n`;
   str += `Warning: \`${warning(options)}\``;
   str += "\n\n";
-  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫${notOk}\n\n`;
+  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫 ${notOk}\n\n`;
   if (rationale) str += `${rationale}\n\n`;
   if (source)
     str += `Sources:\n${source.map(link => `- <${link}>\n`).join("")}\n`;

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -7,7 +7,7 @@ const md = Object.keys(clues).reduce((str, clue) => {
   str += `### ${heading}\n\n`;
   str += `Warning: \`${warning(options)}\``;
   str += "\n\n";
-  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫${notOk}`;
+  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫${notOk}\n\n`;
   if (rationale) str += `${rationale}\n\n`;
   if (source)
     str += `Sources:\n${source.map(link => `- <${link}>\n`).join("")}\n`;

--- a/tests/clues.test.js
+++ b/tests/clues.test.js
@@ -18,17 +18,16 @@ Object.keys(clues).forEach(clue => {
       false,
       "`warning` must not end in period"
     );
-
-    /*
-    assert.ok(
+    /*assert.ok(
       clues[clue].source,
       "must have `source`"
     );
     assert.ok(
       clues[clue].rationale,
       "must have `rationale`"
-    );
-    */
+    );*/
+    assert.ok(clues[clue].ok, "must have `ok`");
+    assert.ok(clues[clue].notOk, "must have `notOk`");
     assert.ok(clues[clue].heading, "must have `heading`");
     if (clues[clue].fn) {
       assert.equal(


### PR DESCRIPTION
Fixes #25 I reused some alt text in these examples, may be good to find fresh content for each