### PR TITLE
Replace "end in period" suggestion with "end in punctuation"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Main
+
+- Replace "End in period" suggestion with "End in punctuation". [#49](https://github.com/double-great/alt-text/pull/49)
+
 ## 0.3.1
 
 - Register "Avoid emoji" suggestion with main script. [#48](https://github.com/double-great/alt-text/pull/48)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ console.log(altText("A child holding a photograph."));
 // undefined
 
 console.log(altText("A photo of a dog"));
-// Alt text should not contain "photo of" (https://git.io/JvqAM). Alt text should end in a period (https://git.io/Jvqiq).
+// Alt text should not contain "photo of" (https://git.io/JvqAM). Alt text should end with punctuation (https://git.io/JJk55).
 ```
 
 ## Suggestions
@@ -130,11 +130,11 @@ Sources:
 
 - <https://www.w3.org/WAI/tutorials/images/tips/#tips>
 
-### End in a period
+### End with punctuation
 
-Suggestion: `Alt text should end in a period`
+Suggestion: `Alt text should end with punctuation`
 
-End the alt text with a period. This will make screen readers pause a bit after the last word in the alt text, which creates a more pleasant reading experience for the user.
+End the alt text with a period, exclamation point, or question mark. This will make screen readers pause a bit after the last word in the alt text, which creates a more pleasant reading experience for the user.
 
 - ✅ A child holding a photograph.
 - 🚫 A child holding a photograph
@@ -142,6 +142,7 @@ End the alt text with a period. This will make screen readers pause a bit after 
 Sources:
 
 - <https://axesslab.com/alt-texts/#end-with-a-period>
+- <https://doublegreat.dev/listen/punctuation-in-alt-text/>
 
 ### Image is decorative
 

--- a/clues.js
+++ b/clues.js
@@ -37,12 +37,15 @@ module.exports = {
     notOk:
       '`<a href="https://github.com/double-great"><img src="logo.png" alt="double great logo"></a>`'
   },
-  endPeriod: {
-    heading: "End in a period",
-    suggestion: () => `Alt text should end in a period`,
+  endPunctuation: {
+    heading: "End with punctuation",
+    suggestion: () => `Alt text should end with punctuation`,
     rationale:
-      "End the alt text with a period. This will make screen readers pause a bit after the last word in the alt text, which creates a more pleasant reading experience for the user.",
-    source: ["https://axesslab.com/alt-texts/#end-with-a-period"],
+      "End the alt text with a period, exclamation point, or question mark. This will make screen readers pause a bit after the last word in the alt text, which creates a more pleasant reading experience for the user.",
+    source: [
+      "https://axesslab.com/alt-texts/#end-with-a-period",
+      "https://doublegreat.dev/listen/punctuation-in-alt-text/"
+    ],
     ok: "A child holding a photograph.",
     notOk: "A child holding a photograph"
   },

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function altText(alt) {
     ...rules.checkClue(alt),
     ...rules.checkLength(alt),
     ...rules.checkOnlySpace(alt),
-    ...rules.checkPeriod(alt),
+    ...rules.checkPunctuation(alt),
     ...rules.checkEmoji(alt)
   ];
   return suggestion.length ? suggestion.join(" ") : undefined;

--- a/rules.js
+++ b/rules.js
@@ -29,9 +29,10 @@ function checkOnlySpace(alt) {
   return alt == " " ? [createSuggestion("notOnlySpace")] : [];
 }
 
-function checkPeriod(alt) {
-  return !alt.endsWith(".") && alt.length > 1
-    ? [createSuggestion("endPeriod")]
+function checkPunctuation(alt) {
+  console.log("test", /[.!?]$/.test(alt));
+  return !/[.!?]$/.test(alt) && alt.length > 1
+    ? [createSuggestion("endPunctuation")]
     : [];
 }
 
@@ -45,7 +46,7 @@ module.exports = {
   checkClue,
   checkLength,
   checkOnlySpace,
-  checkPeriod,
+  checkPunctuation,
   createSuggestion,
   checkEmoji
 };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -36,12 +36,12 @@ test("[altText] return suggestions", assert => {
 
   assert.equal(
     altText("A SCREENSHOT OF A DOG"),
-    'Alt text should not contain "screenshot of" (https://git.io/JvqAM). Alt text should end in a period (https://git.io/Jvqiq).',
+    'Alt text should not contain "screenshot of" (https://git.io/JvqAM). Alt text should end with punctuation (https://git.io/JJk55).',
     "more than one suggestion"
   );
   assert.equal(
     altText("An inhaler with a spacer connected to the mouthpiece"),
-    "Alt text should end in a period (https://git.io/Jvqiq)."
+    "Alt text should end with punctuation (https://git.io/JJk55)."
   );
   assert.equal(
     altText("😸."),

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -47,10 +47,13 @@ test("[rules] checkClue.contain", assert => {
   assert.end();
 });
 
-test("[rules] checkPeriod", assert => {
-  assert.deepEqual(rules.checkPeriod("a large black dog"), [
-    "Alt text should end in a period (https://git.io/Jvqiq)."
+test("[rules] checkPunctuation", assert => {
+  assert.deepEqual(rules.checkPunctuation("a large black dog"), [
+    "Alt text should end with punctuation (https://git.io/JJk55)."
   ]);
+  assert.deepEqual(rules.checkPunctuation("a large black dog."), []);
+  assert.deepEqual(rules.checkPunctuation("a large black dog!"), []);
+  assert.deepEqual(rules.checkPunctuation("a large black dog?"), []);
   assert.end();
 });
 

--- a/urls.json
+++ b/urls.json
@@ -3,7 +3,7 @@
   "charLength": "https://git.io/Jvfxm",
   "contains": "https://git.io/JvqAM",
   "decorative": "https://git.io/Jvqx8",
-  "endPeriod": "https://git.io/Jvqiq",
+  "endPunctuation": "https://git.io/JJk55",
   "endWith": "https://git.io/JvfAf",
   "exactMatch": "https://git.io/JvqAK",
   "imageLink": "https://git.io/JvfNj",


### PR DESCRIPTION
This PR replaces the "end in period" suggestion with "end in punctuation" `.`, `!`, or `?`.

@jsnmrs Not sure if it's worth noting anywhere that a question mark will cause an audible inflection change. What do you think?

We should wait for https://github.com/double-great/listen/pull/2 to merge before merging this as it contains an updated url path that is references in this PR.

Fixes #40 

Ref #43 