### PR TITLE
Move "Listen" links into own section?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Main
 
-- Add Emoji in alt text link as a source to "Avoid emoji" suggestion. [#58](https://github.com/double-great/alt-text/pull/57)
+- Add "Hear an example" section to documentation and include links under "Avoid emoji" and "End with punctuation" suggestions. [#58](https://github.com/double-great/alt-text/pull/58)
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,11 @@ End the alt text with a period, exclamation point, or question mark. This will m
 - ✅ A child holding a photograph.
 - 🚫 A child holding a photograph
 
+Hear an example: <https://doublegreat.dev/listen/punctuation-in-alt-text/>
+
 Sources:
 
 - <https://axesslab.com/alt-texts/#end-with-a-period>
-- <https://doublegreat.dev/listen/punctuation-in-alt-text/>
 
 ### Image is decorative
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,12 @@ Emoji have their own text descriptions. These descriptions can vary between oper
 - ✅ `<img src="cat.jpg" alt="An orange cat.">`
 - 🚫 `<img src="cat.png" alt="An orange 🐈."/>`
 
+Hear an example: <https://doublegreat.dev/listen/emoji/>
+
 Sources:
 
 - <https://www.youtube.com/watch?v=uIbPcZq6izk>
 - <https://readabilityguidelines.co.uk/images/emojis/>
-- <https://doublegreat.dev/listen/emoji/>
 
 ### Character length
 

--- a/clues.js
+++ b/clues.js
@@ -42,10 +42,8 @@ module.exports = {
     suggestion: () => `Alt text should end with punctuation`,
     rationale:
       "End the alt text with a period, exclamation point, or question mark. This will make screen readers pause a bit after the last word in the alt text, which creates a more pleasant reading experience for the user.",
-    source: [
-      "https://axesslab.com/alt-texts/#end-with-a-period",
-      "https://doublegreat.dev/listen/punctuation-in-alt-text/",
-    ],
+    listen: "https://doublegreat.dev/listen/punctuation-in-alt-text/",
+    source: ["https://axesslab.com/alt-texts/#end-with-a-period"],
     ok: "A child holding a photograph.",
     notOk: "A child holding a photograph",
   },

--- a/clues.js
+++ b/clues.js
@@ -174,10 +174,10 @@ module.exports = {
     suggestion: (emoji) =>
       `Replace ${emoji || "emoji"} in alt text with descriptive text`,
     rationale: `Emoji have their own text descriptions. These descriptions can vary between operating systems and software. The spoken description of the emoji may not match your visual intention.`,
+    listen: "https://doublegreat.dev/listen/emoji/",
     source: [
       "https://www.youtube.com/watch?v=uIbPcZq6izk",
       "https://readabilityguidelines.co.uk/images/emojis/",
-      "https://doublegreat.dev/listen/emoji/",
     ],
     ok: '`<img src="cat.jpg" alt="An orange cat.">`',
     notOk: '`<img src="cat.png" alt="An orange 🐈."/>`',

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -9,12 +9,22 @@ const sortedClues = Object.keys(clues)
   .sort((a, b) => a.heading.localeCompare(b.heading));
 
 const md = sortedClues.reduce((str, clue) => {
-  const { suggestion, rationale, source, heading, rules, ok, notOk } = clue;
+  const {
+    suggestion,
+    rationale,
+    source,
+    heading,
+    rules,
+    ok,
+    notOk,
+    listen,
+  } = clue;
   str += `### ${heading}\n\n`;
   str += `Suggestion: \`${suggestion(rules ? rules.sort().join(", ") : "")}\``;
   str += "\n\n";
   if (rationale) str += `${rationale}\n\n`;
   if (ok && notOk) str += `- ✅ ${ok}\n- 🚫 ${notOk}\n\n`;
+  if (listen) str += `Hear an example: <${listen}>\n\n`;
   if (source)
     str += `Sources:\n${source.map((link) => `- <${link}>\n`).join("")}\n`;
   return str;

--- a/tests/clues.test.js
+++ b/tests/clues.test.js
@@ -45,6 +45,17 @@ Object.keys(clues).forEach((clue) => {
         assert.equal(rule, rule.toLowerCase(), `"${rule}" must be lowercase`);
       });
     }
+    if (clues[clue].listen) {
+      assert.equal(
+        typeof clues[clue].listen,
+        "string",
+        "`listen` must be a string"
+      );
+      assert.ok(
+        clues[clue].listen.startsWith("https://"),
+        "`listen` must start with 'https://'"
+      );
+    }
 
     assert.end();
   });


### PR DESCRIPTION
Thinking about #43: I'm wondering if instead of adding Listen links as sources, we should call them out like:

> Hear an example: <https://doublegreat.dev/listen/punctuation-in-alt-text/>

In context:

> ![image](https://user-images.githubusercontent.com/2180540/86545035-a99d1680-bef9-11ea-9a9f-9b3bf536a4f9.png)


I think "Hear an example" wording could be improved, but I'm having writers block right now.

Maybe:

- "Hear how different screen readers handle this use case:"
- "Listen to how different screen readers interpret it:"