### PR TITLE
Create tests for write-docs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run write-docs && git add README.md && npm run pretty-quick --staged
+npx pretty-quick --staged

--- a/scripts/write-docs-utils.js
+++ b/scripts/write-docs-utils.js
@@ -1,0 +1,46 @@
+import { readFileSync, writeFile } from "fs";
+
+function sortClues(clues) {
+  return Object.keys(clues)
+    .reduce((arr, item) => {
+      clues[item].id = item;
+      return (arr = [...arr, clues[item]]);
+    }, [])
+    .sort((a, b) => a.heading.localeCompare(b.heading));
+}
+
+export function formatDocs(clues) {
+  const sortedClues = sortClues(clues);
+  return sortedClues.reduce((str, clue) => {
+    const { suggestion, rationale, source, heading, rules, ok, notOk, listen } =
+      clue;
+    str += `### ${heading}\n\n`;
+    str += `Suggestion: \`${suggestion(
+      rules ? rules.sort().join(", ") : ""
+    )}\``;
+    str += "\n\n";
+    if (rationale) str += `${rationale}\n\n`;
+    if (ok && notOk) str += `- ✅ ${ok}\n- 🚫 ${notOk}\n\n`;
+    if (listen) str += `Hear an example: <${listen}>\n\n`;
+    if (source)
+      str += `Sources:\n${source.map((link) => `- <${link}>\n`).join("")}\n`;
+    return str;
+  }, "## Suggestions\n\n<!-- this section is generated on commit !-->\n\n");
+}
+
+export function writeDocs(clues) {
+  const md = formatDocs(clues);
+  const { currentDocs, matchedDocs } = swapDocs();
+  const newFile = currentDocs.replace(matchedDocs, md);
+  writeFile("README.md", newFile, () => {
+    console.log("Updated README.md");
+  });
+}
+
+export function swapDocs() {
+  const readme = readFileSync("./README.md", "utf-8");
+  return {
+    currentDocs: readme,
+    matchedDocs: readme.match(/## Suggestions([\s\S]*)/g),
+  };
+}

--- a/scripts/write-docs.js
+++ b/scripts/write-docs.js
@@ -1,39 +1,4 @@
-import { readFileSync, writeFileSync } from "fs";
+import { writeDocs } from "./write-docs-utils.js";
 import clues from "../clues.js";
 
-
-const sortedClues = Object.keys(clues)
-  .reduce((arr, item) => {
-    clues[item].id = item;
-    return (arr = [...arr, clues[item]]);
-  }, [])
-  .sort((a, b) => a.heading.localeCompare(b.heading));
-
-const md = sortedClues.reduce((str, clue) => {
-  const {
-    suggestion,
-    rationale,
-    source,
-    heading,
-    rules,
-    ok,
-    notOk,
-    listen,
-  } = clue;
-  str += `### ${heading}\n\n`;
-  str += `Suggestion: \`${suggestion(rules ? rules.sort().join(", ") : "")}\``;
-  str += "\n\n";
-  if (rationale) str += `${rationale}\n\n`;
-  if (ok && notOk) str += `- ✅ ${ok}\n- 🚫 ${notOk}\n\n`;
-  if (listen) str += `Hear an example: <${listen}>\n\n`;
-  if (source)
-    str += `Sources:\n${source.map((link) => `- <${link}>\n`).join("")}\n`;
-  return str;
-}, "## Suggestions\n\n<!-- this section is generated on commit !-->\n\n");
-
-const readme = readFileSync("readme.md", "utf-8");
-const regex = /## Suggestions([\s\S]*)/g;
-const oldFile = readme.match(regex);
-const newFile = readme.replace(oldFile, md);
-
-writeFileSync("README.md", newFile);
+writeDocs(clues);

--- a/tests/write-docs.test.js
+++ b/tests/write-docs.test.js
@@ -1,0 +1,9 @@
+import { formatDocs, swapDocs } from "../scripts/write-docs-utils.js";
+import clues from "../clues.js";
+
+describe("Documentation in README.md is up-to-date", () => {
+  it("Run `npm run write-docs` to update documentation", () => {
+    const { matchedDocs } = swapDocs();
+    expect(formatDocs(clues)).toEqual(matchedDocs[0]);
+  });
+});


### PR DESCRIPTION
To better support #167, this PR refactors how we handle the generation of documentation. Instead of using a precommit hook, we'll add a test to make sure that the content in the README matches the expected output. If it does not match, the test will remind you to run `npm run update-docs`.