### PR TITLE
Set `versioning-strategy` dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase


### PR DESCRIPTION
I noticed that dependabot is only updating package-lock.json and not package.json. From this StackOverflow thread, we can try setting the versioning strategy and that should bump both files: https://stackoverflow.com/a/66819358/2887392